### PR TITLE
Add support for 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.marcely</groupId>
 	<artifactId>WarpGUI</artifactId>
-	<version>2.5</version>
+	<version>2.6</version>
 
 	<repositories>
 		<repository>
 			<id>spigotmc-repo</id>
-			<url>http://hub.spigotmc.org/nexus/content/groups/public</url>
+			<url>https://hub.spigotmc.org/nexus/content/groups/public</url>
 		</repository>
 		<repository>
 			<id>ess-repo</id>
@@ -32,13 +32,13 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
+			<version>1.18.24</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains</groupId>
 			<artifactId>annotations</artifactId>
-			<version>22.0.0</version>
+			<version>23.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.ess3</groupId>

--- a/src/main/java/de/marcely/warpgui/version/Version.java
+++ b/src/main/java/de/marcely/warpgui/version/Version.java
@@ -36,7 +36,9 @@ public enum Version {
     R1_17(17, 1),
 
     R1_18(18, 1),
-    R2_18(18, 2);;
+    R2_18(18, 2),
+
+    R1_19(19, 1);
 
     @Getter
     private static VersionInstance current;
@@ -80,7 +82,7 @@ public enum Version {
 			logger.warning("Stopping the plugin...");
 
 			Bukkit.getPluginManager().disablePlugin(plugin);
-			
+
 			return false;*/
         }
 


### PR DESCRIPTION
This PR adds support for Minecraft 1.19 in the versions list and updates some dependencies.

I tested most commands and couldn't find any regressions.